### PR TITLE
refactor: 'input' and `textarea` styles

### DIFF
--- a/src/global/ui/input/input.scss
+++ b/src/global/ui/input/input.scss
@@ -1,34 +1,29 @@
 
 .input {
   position: relative;
-  padding: 0 1px;
+  /*! @skip-scaling */
+  padding: 1px;
   width: 100%;
   background: linear-gradient(267.05deg, #C58B5D 0%, #FFB57B 100%);
   border-radius: 100px;
 
-  &::before {
-    content: '';
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    width: calc(100% - 2px);
-    height: calc(100% - 2px);
-    background-color: var(--white);
-    transform: translateX(-50%) translateY(-50%);
-    transform-origin: 0 0;
-    border-radius: 100px;
-  }
-
-  input {
+  input, textarea {
     caret-color: var(--black_100);
     position: relative;
     z-index: 1;
     padding: 20px 40px;
     width: 100%;
     height: 100%;
+    display: block;
     border-radius: 100px;
     font-size: 1.6rem;
     line-height: 1.1;
-    text-transform: uppercase;
+    outline: none;
+    border: 0;
+    background: white;
+
+    &:placeholder-shown {
+      text-transform: uppercase;
+    }
   }
 }

--- a/src/global/ui/textarea/textarea.scss
+++ b/src/global/ui/textarea/textarea.scss
@@ -1,17 +1,5 @@
 .textarea {
   textarea {
-    position: relative;
-    z-index: 1;
-    padding: 20px 40px;
-    width: 100%;
-    height: 100%;
-    border-radius: 100px;
-    font-size: 1.6rem;
-    line-height: 1.1;
-    text-transform: uppercase;
-    outline: none;
-    border: 0;
     resize: none;
-    background: transparent;
   }
 }


### PR DESCRIPTION
### Исправлено
- Стили `.input` и `.textarea` объедены в один
- Убран `::before` элемент из `.input`